### PR TITLE
Adding init method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quick.db",
-    "version": "7.1.3",
+    "version": "7.2.0",
     "description": "An easy, non-locking, persistent better-sqlite3 wrapper designed to be easy to setup & utilize",
     "main": "index.js",
     "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,6 @@ const Database = require("better-sqlite3");
 const util = require("util");
 let db;
 
-// Create Database Under Conditions
-if (!db) db = new Database("./json.sqlite");
 
 // Declare Methods
 var methods = {

--- a/src/methods/init.js
+++ b/src/methods/init.js
@@ -1,0 +1,20 @@
+// Require Packages
+const get = require('lodash/get');
+const set = require('lodash/set');
+
+module.exports = function(db, params, options) {
+  
+   /**
+ * This function initialize the database on the sqlite file of your choice.
+ * @param {string} dbname the string of the sqlite file path
+ * @returns {boolean} if it was a success or not.
+ */
+
+ init: function(dbpath='./json.sqlite'){
+    db = new Database(dbpath);
+    return true;
+ },
+// If the database has not previously been defined by the init function
+  if(!db) db = new Database('./json.sqlite');
+  
+}


### PR DESCRIPTION
This pull request allows, via db.init, to choose the location of the quick.db database.
This should solve the problem in #171 