### PR TITLE
Fix when key (id) is number and not a string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -355,6 +355,7 @@ module.exports = function(file) {
     };
 
     function arbitrate(method, params, tableName) {
+        if(typeof params.id == 'number') params.id = params.id.toString()
         // Configure Options
         let options = {
             table: tableName || params.ops.table || "json",


### PR DESCRIPTION
db.set(Date.now(), "data here")
This would throw this error:
if (params.id && params.id.includes(".")) {
TypeError: params.id.includes is not a function

I could convert it to string but it should be handled by the lib.