### PR TITLE
always return json instead of stringified object

### DIFF
--- a/src/methods/all.js
+++ b/src/methods/all.js
@@ -5,9 +5,11 @@ module.exports = function(db, params, options) {
   let resp = [];
   for (var row of stmt.iterate()) {
     try {
+      let data = JSON.parse(row.json)
+      if(typeof data == 'string') data = JSON.parse(data)
       resp.push({
         ID: row.ID,
-        data: JSON.parse(row.json)
+        data
       })
     } catch (e) {}
   }


### PR DESCRIPTION
Sometimes .all method returns data property that is string and not parsed object. This fixes it.